### PR TITLE
Upgrade Node 20-deprecated Actions (pkm#531)

### DIFF
--- a/.github/workflows/agentdb-learning.yml
+++ b/.github/workflows/agentdb-learning.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract PR metadata
         id: metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Upgrades first-party GitHub Actions pinned to the deprecated Node 20 (or older Node 16) runtime to their first Node 24-compatible major.

GitHub forced Node 24 as the default Actions runtime on 2026-06-02; Node 20 is removed from runners on 2026-09-16. Tracked in michaeloboyle/pkm#531.

checkout v3/v4->v5, setup-node v4->v5, setup-python v5->v6, github-script v6/v7->v8, upload/download-artifact v4->v5, cache v4->v5, configure-pages v4->v6, deploy-pages v4->v5, labeler v5->v6, setup-java v4->v5.

Third-party actions (google-github-actions/*, codecov, firebase-action, etc.) are maintainer-owned and left as-is. Bumped to the first Node 24 major (not absolute latest) to minimize breaking-change surface.

Generated with Claude Code.